### PR TITLE
fix: generate 403 error

### DIFF
--- a/app.go
+++ b/app.go
@@ -301,6 +301,7 @@ func (a *App) GenerateRepo(req GenerateRepoRequest) (*GenerateRepoResponse, erro
 	_ = a.runGitCommand(repoPath, "config", "gc.auto", "0")
 	_ = a.runGitCommand(repoPath, "config", "core.autocrlf", "false")
 	_ = a.runGitCommand(repoPath, "config", "core.fsyncObjectFiles", "false")
+	_ = a.runGitCommand(repoPath, "config", "credential.helper", "") // ensure global helpers can't override askpass
 
 	// Sort contributions by date ascending to produce chronological history
 	contribs := make([]ContributionDay, 0, len(req.Contributions))


### PR DESCRIPTION
fix #51 
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes 403 errors during repo generation by disabling Git credential helpers at the repo level so global helpers can’t override askpass. Ensures the intended credentials are used consistently.

<sup>Written for commit 21bd7a0d518cb2c1647b1f12ddea8875be9fede6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

