### PR TITLE
feat(i18n): add placeholder text for workbench area

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - '**'
+      - main
     tags:
       - 'v*'
   pull_request:

--- a/frontend/src/components/ContributionCalendar.tsx
+++ b/frontend/src/components/ContributionCalendar.tsx
@@ -1124,12 +1124,7 @@ function ContributionCalendar({
           />
         </aside>
         <aside className="workbench__panel">
-          <p className="text-center">
-            ✨ 该区域正在筹备中！各位大神有哪些脑洞大开的功能想法？快来 issues
-            留言，你的创意可能会被实现哦～
-            <br />✨ This area is in the works! Do you have any creative function ideas, dear users?
-            Leave a comment in the issues—your creativity might be realized!
-          </p>
+          <p className="text-center">{t('workbench.placeholder')}</p>
         </aside>
       </div>
       {isRemoteModalOpen && (

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -99,6 +99,9 @@ type TranslationDict = {
     legendLess: string;
     legendMore: string;
   };
+  workbench: {
+    placeholder: string;
+  };
   characterSelector: {
     title: string;
     selectCharacter: string;
@@ -256,6 +259,10 @@ const translations: Record<Language, TranslationDict> = {
       legendLess: 'Less',
       legendMore: 'More',
     },
+    workbench: {
+      placeholder:
+        '✨ This area is under development! Got any wild feature ideas? Drop them in the issues and your creativity might ship~ Tips: Right-click to switch between the brush and eraser. In copy mode, select a pattern, press Ctrl+C to copy it, then Ctrl+V or left-click to paste.',
+    },
     characterSelector: {
       title: 'Select Pattern',
       selectCharacter: 'Select Character (A-Z, a-z, 0-9)',
@@ -407,6 +414,10 @@ const translations: Record<Language, TranslationDict> = {
       tooltipFuture: '{{date}} 为未来日期，禁止编辑',
       legendLess: '较少',
       legendMore: '更多',
+    },
+    workbench: {
+      placeholder:
+        '✨ 该区域正在开发中！大家有哪些脑洞大开的功能想法？快来 issues 留言，你的创意可能会被实现哦~操作说明：右键可以切换画笔和橡皮擦，复制模式下框选好图案后按 ctrl+C 复制图案，ctrl+V 或者左键粘贴图案',
     },
     characterSelector: {
       title: '选择图案',


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Localized the workbench placeholder message and added usage tips for brush/eraser and copy mode in English and Chinese. Replaced hardcoded text in ContributionCalendar with t('workbench.placeholder'), added the workbench.placeholder i18n key, and limited the Build workflow to pushes on main.

<sup>Written for commit cbc1b0507e2477ada796e6523f83a74efe24d43b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



