### PR TITLE
feat: add random active contribution generator

### DIFF
--- a/frontend/src/components/ContributionCalendar.tsx
+++ b/frontend/src/components/ContributionCalendar.tsx
@@ -293,6 +293,7 @@ function ContributionCalendar({
     handleTileMouseUp,
     reset,
     fillAllGreen,
+    randomActiveContributions,
     exportContributions,
     importContributions,
     openRemoteModal,
@@ -797,6 +798,15 @@ function ContributionCalendar({
 
             <button type="button" className="workspace__dock-button" onClick={fillAllGreen}>
               <span>{t('buttons.allGreen')}</span>
+            </button>
+            <button
+              type="button"
+              className="workspace__dock-button"
+              onClick={randomActiveContributions}
+              title={t('titles.randomActive')}
+            >
+              <AutoIcon className="workspace__dock-icon" />
+              <span>{t('buttons.randomActive')}</span>
             </button>
             <button type="button" className="workspace__dock-button" onClick={reset}>
               <span>{t('buttons.reset')}</span>

--- a/frontend/src/hooks/useContributionEditor.ts
+++ b/frontend/src/hooks/useContributionEditor.ts
@@ -26,6 +26,36 @@ function getNextContribution(current: number): number {
   return current;
 }
 
+function getRandomActiveContribution(dateStr: string, previousWasActive: boolean): number {
+  const date = parseIsoDate(dateStr);
+  const day = date.getDay();
+  const isWeekend = day === 0 || day === 6;
+  const monthWave = 0.08 * Math.sin((date.getMonth() / 12) * Math.PI * 2);
+  const streakBoost = previousWasActive ? 0.12 : 0;
+  const activityChance = clampProbability((isWeekend ? 0.48 : 0.87) + monthWave + streakBoost);
+
+  if (Math.random() > activityChance) {
+    return 0;
+  }
+
+  const roll = Math.random();
+  if (isWeekend) {
+    if (roll < 0.58) return 1;
+    if (roll < 0.86) return 3;
+    if (roll < 0.97) return 6;
+    return 9;
+  }
+
+  if (roll < 0.18) return 1;
+  if (roll < 0.52) return 3;
+  if (roll < 0.84) return 6;
+  return 9;
+}
+
+function clampProbability(value: number): number {
+  return Math.min(Math.max(value, 0.05), 0.98);
+}
+
 function characterToPattern(char: string): boolean[][] {
   const pattern = getPatternById(char);
   if (pattern) {
@@ -453,6 +483,31 @@ export function useContributionEditor({
           nextMap.set(entry.date, 9);
         }
       }
+      return nextMap;
+    });
+  }, [filteredContributions, isFutureDate, pushSnapshot, setUserContributions]);
+
+  const randomActiveContributions = React.useCallback(() => {
+    pushSnapshot();
+    setUserContributions((previous) => {
+      const nextMap = new Map(previous);
+      let previousWasActive = false;
+
+      for (const entry of filteredContributions) {
+        if (isFutureDate(entry.date)) {
+          continue;
+        }
+
+        const count = getRandomActiveContribution(entry.date, previousWasActive);
+        previousWasActive = count > 0;
+
+        if (count > 0) {
+          nextMap.set(entry.date, count);
+        } else {
+          nextMap.delete(entry.date);
+        }
+      }
+
       return nextMap;
     });
   }, [filteredContributions, isFutureDate, pushSnapshot, setUserContributions]);
@@ -890,6 +945,7 @@ export function useContributionEditor({
     handleTileMouseUp,
     reset,
     fillAllGreen,
+    randomActiveContributions,
     exportContributions,
     importContributions,
     openRemoteModal,

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -28,6 +28,7 @@ type TranslationDict = {
   };
   buttons: {
     allGreen: string;
+    randomActive: string;
     reset: string;
     copyMode: string;
     generateRepo: string;
@@ -43,6 +44,7 @@ type TranslationDict = {
     penManualMode: string;
     penAutoMode: string;
     allGreen: string;
+    randomActive: string;
     reset: string;
     copyMode: string;
     generate: string;
@@ -220,6 +222,7 @@ const translations: Record<Language, TranslationDict> = {
     },
     buttons: {
       allGreen: 'All Green',
+      randomActive: 'Random Active',
       reset: 'Reset',
       copyMode: 'Copy Mode',
       generateRepo: 'Generate Repo',
@@ -235,6 +238,7 @@ const translations: Record<Language, TranslationDict> = {
       penManualMode: 'Manual Mode',
       penAutoMode: 'Auto Mode',
       allGreen: 'Set all contributions to green',
+      randomActive: 'Randomly generate a realistic frequent contributor pattern',
       reset: 'Clear all customised contribution data',
       generate: 'Create a local git repository matching this contribution calendar',
       export: 'Export current contributions to a JSON file',
@@ -417,6 +421,7 @@ const translations: Record<Language, TranslationDict> = {
     },
     buttons: {
       allGreen: '全绿',
+      randomActive: '随机活跃',
       reset: '重置',
       copyMode: '复制模式',
       generateRepo: '生成仓库',
@@ -432,6 +437,7 @@ const translations: Record<Language, TranslationDict> = {
       penManualMode: '手动模式',
       penAutoMode: '自动模式',
       allGreen: '将所有贡献设置为绿色',
+      randomActive: '随机生成真实的高频贡献者分布',
       reset: '清除所有自定义贡献数据',
       generate: '创建与当前贡献图匹配的本地 Git 仓库',
       export: '导出当前贡献数据到 JSON 文件',


### PR DESCRIPTION
## Summary

This PR adds a "Random Active" generator for the current contribution calendar year. It helps users quickly create a realistic-looking contribution pattern that resembles a frequent GitHub contributor, instead of manually painting every day or filling the entire year uniformly.

## How It Works

The generator creates contributions day by day for the selected year, skipping future dates in the current year.

The random model is designed to avoid flat noise:

- Weekdays have a higher base activity probability than weekends.
- If the previous day was active, the next day gets a small probability boost, which naturally creates contribution streaks.
- A light monthly sine wave slightly changes activity density across the year, so the calendar does not look evenly distributed.
- Active days are assigned contribution counts from `1`, `3`, `6`, or `9`, matching the existing contribution intensity levels.
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.37.54.png)
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.37.44.png)
Current probabilities:

- Weekdays start around `87%` active.
- Weekends start around `48%` active.
- Consecutive active days add a `12%` streak boost.
- Monthly variation adds up to `±8%`.

Contribution intensity also differs by weekday/weekend:

- Weekends are more likely to produce low-intensity contributions.
- Weekdays are more likely to produce medium or high-intensity contributions.

This produces a pattern with frequent workday activity, lighter weekend activity, natural streaks, and varied contribution strength.

## UI Changes

- Adds a new dock button: `Random Active`.
- Adds English and Chinese translations.
- The generated pattern works with the existing editor state, undo history, export flow, and repository generation flow.
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.37.29.png)
## Testing

- Ran `npm run build`
- Ran `go test ./...`


## 概述

这个 PR 新增了一个「随机活跃」功能，可以为当前选中的年份快速生成一组更接近真实高频 GitHub 贡献者的 contribution 分布。相比手动绘制或一键全绿，它生成的图案更自然，不会像均匀噪声或机械填充。

## 实现原理

生成器会按日期逐天生成当前年份的贡献数据，并且会跳过当前年份中的未来日期。

随机模型不是完全独立地给每一天撒点，而是加入了几个模拟真实使用习惯的因素：

- 工作日的基础活跃概率高于周末。
- 如果前一天有贡献，第二天会获得额外概率加成，用来模拟连续贡献 streak。
- 使用轻微的月份周期波动，让一年中的活跃密度有自然起伏，避免全年看起来过于平均。
- 活跃日期会被分配到现有的贡献强度级别：`1`、`3`、`6`、`9`。
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.35.05.png)
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.34.50.png)
当前概率设计：

- 工作日基础活跃概率约为 `87%`。
- 周末基础活跃概率约为 `48%`。
- 前一天活跃会带来 `12%` 的连续贡献加成。
- 月份波动最多带来 `±8%` 的活跃概率变化。

贡献强度也区分工作日和周末：

- 周末更容易生成低强度贡献。
- 工作日更容易生成中高强度贡献。

最终效果是：工作日较密集，周末较轻，带有自然连续 streak，并且贡献强度有层次。

## UI 变化

- 新增底部工具栏按钮：「随机活跃」。
- 补充英文和中文翻译。
- 生成结果接入现有编辑状态，支持撤销、导出和生成仓库流程。
![](https://somnusblog.oss-cn-shanghai.aliyuncs.com/images/%E6%88%AA%E5%B1%8F2026-05-12%2009.32.40.png)
## 测试

- 已运行 `npm run build`
- 已运行 `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Random Active" generator to quickly create a realistic frequent‑contributor pattern for the selected year, skipping future dates. Integrates with undo, export, and repo generation.

- **New Features**
  - Adds a dock button: Random Active (with tooltip).
  - Probabilistic model: weekday/weekend bias, small streak boost, light monthly wave.
  - Assigns counts 1/3/6/9; weekends favor lower intensity.
  - Skips future dates and respects the filtered range.
  - Adds English and Chinese translations for the button and tooltip.

<sup>Written for commit fb38332d8493f77a9a523d2c87beadde5ae84717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

